### PR TITLE
Bug fix when using skyfield

### DIFF
--- a/nustar_pysolar/planning.py
+++ b/nustar_pysolar/planning.py
@@ -116,7 +116,7 @@ def get_skyfield_position(time, offset, load_path=None, parallax_corection=False
     from astropy.time import Time
     import sunpy.sun
 
-    if load_path is False:
+    if load_path is None:
         load_path = './'
         load=Loader(load_path)
     else:
@@ -145,7 +145,7 @@ def get_skyfield_position(time, offset, load_path=None, parallax_corection=False
 
 
 
-    geocentric = observer.at(tcheck).observe(sun)
+    geocentric = observer.at(tcheck).observe(sun).apparent()
     this_ra_geo, this_dec_geo, dist = geocentric.radec()
 
 


### PR DESCRIPTION
This fixes the bug in `get_skyfield_position()` where only the astrometric position is used, not the apparent position, so aberration (up to ~20 arcsec) is not taken into account.  I haven't re-run the notebook comparing Astropy and skyfield, but spot-checking shows that the discrepancy drops to milliarcsec.