### PR TITLE
Bug fix for map grid

### DIFF
--- a/nustar_pysolar/map.py
+++ b/nustar_pysolar/map.py
@@ -83,7 +83,8 @@ def make_sunpy(evtdata, hdr):
 	"HGLN_OBS": 0,
 	"RSUN_OBS": sun.solar_semidiameter_angular_size(mid_obs_time).value,
 	"RSUN_REF": sun.constants.radius.value,
-	"DSUN_OBS": sun.sunearth_distance(mid_obs_time).value
+	# Assumes dsun_obs in m if don't specify the units, so give units
+	"DSUN_OBS": sun.sunearth_distance(mid_obs_time).value*u.astrophys.au
 	}
 	# For some reason the DSUN_OBS crashed the save...
 


### PR DESCRIPTION
Fixed the bug in map.py that resulted in the lat-lon grid not plotting properly. Problem was with dsun_obs in map header. If no units specified, sunpy assumes in metres. We were giving number of AU, without specifing units. Fixed by giving dsun_obs AU units.