### PR TITLE
map.make_sunpy: added unit support, tidied comments.

### DIFF
--- a/nustar_pysolar/map.py
+++ b/nustar_pysolar/map.py
@@ -10,7 +10,7 @@ import astropy.units as u
 import logging
 
 
-def make_sunpy(evtdata, hdr, exp_time=0,on_time=0,norm_map=False,shevt_xy=[0,0]):
+def make_sunpy(evtdata, hdr, exp_time=0, on_time=0, norm_map=False, shevt_xy=(0,0)*u.arcsec):
     """ Make a sunpy map based on the NuSTAR data.
     
     Parameters
@@ -30,7 +30,7 @@ def make_sunpy(evtdata, hdr, exp_time=0,on_time=0,norm_map=False,shevt_xy=[0,0])
     norm_map: Normalise the map data by the exposure time (i.e. livetime), 
         giving map in units of DN/s. Defaults to "False" and units of DN
     
-    shevt_xy: 2 element array of x and y arcsec shift to apply to 
+    shevt_xy: 2 element array of x and y shift to apply to 
     	evtdata before making the map (does to nearest pixel),
     	defaults to [0,0], so no shift
     
@@ -38,88 +38,90 @@ def make_sunpy(evtdata, hdr, exp_time=0,on_time=0,norm_map=False,shevt_xy=[0,0])
     -------
 
     nustar_map:
-        A sunpy map objecct
+        A sunpy map object
     
     """
+    
     # Parse Header keywords
     for field in list(hdr.keys()):
         if field.find('TYPE') != -1:
             if hdr[field] == 'X':
-#                 print(hdr[field][5:8])
                 xval = field[5:8]
             if hdr[field] == 'Y':
-#                 print(hdr[field][5:8])
                 yval = field[5:8]
 
-    min_x= hdr['TLMIN'+xval]
-    min_y= hdr['TLMIN'+yval]
-    max_x= hdr['TLMAX'+xval]
-    max_y= hdr['TLMAX'+yval]
+    min_x = hdr[f'TLMIN{xval}']
+    min_y = hdr[f'TLMIN{yval}']
+    max_x = hdr[f'TLMAX{xval}']
+    max_y = hdr[f'TLMAX{yval}']
 
-    delx = abs(hdr['TCDLT'+xval])
-    dely = abs(hdr['TCDLT'+yval])
+    xunit = u.Unit(hdr[f'TCUNI{xval}'])
+    delx = abs(hdr[f'TCDLT{xval}']) * xunit
+
+    yunit = u.Unit(hdr[f'TCUNI{yval}'])
+    dely = abs(hdr[f'TCDLT{yval}']) * yunit
 
     x = evtdata['X'][:]
     y = evtdata['Y'][:]
-    # Apply a shift to the data - default is 0
-    x = x + round(shevt_xy[0]/delx)
-    y = y + round(shevt_xy[1]/dely)
 
-    met = evtdata['TIME'][:]*u.s
-    mjdref=hdr['MJDREFI']
+    # Apply a shift to the data - default is 0
+    x = x + round( (shevt_xy[0] / delx).decompose().value )
+    y = y + round( (shevt_xy[1] / dely).decompose().value )
+
+    met = evtdata['TIME'][:] * u.s
+    mjdref = hdr['MJDREFI']
 
     mid_obs_time = astropy.time.Time(mjdref*u.d+met.mean(), format = 'mjd')
     sta_obs_time = astropy.time.Time(mjdref*u.d+met.min(), format = 'mjd')
 
     # Get the exposure and ontimes, just a numbers not units of seconds
-    if (exp_time ==0):
-        exp_time=hdr['EXPOSURE']
-    if (on_time ==0):
-        on_time=hdr['ONTIME']    
-
+    if (exp_time == 0):
+        exp_time = hdr['EXPOSURE']
+    if (on_time == 0):
+        on_time = hdr['ONTIME']
+        
     # Use the native binning for now
-
     # Assume X and Y are the same size
     resample = 1.0
     scale = delx * resample
     bins = (max_x - min_x) / (resample)
 
-#   numpy error that histogram2d needs integer number of bins -> fixed  
-    H, yedges, xedges = np.histogram2d(y, x, bins=int(bins), range = [[min_y,max_y], [min_x, max_x]])
+    # numpy error that histogram2d needs integer number of bins -> fixed  
+    H, yedges, xedges = np.histogram2d(y, x, bins=int(bins), range=[[min_y,max_y], [min_x, max_x]])
 
-    #Normalise the data with the exposure (or live) time?
+    # Normalise the data with the exposure (or live) time?
     if norm_map is True:
-    	H=H/exp_time
-    	pixluname='DN/s'
+        H = H / exp_time
+        pixluname = 'DN/s'
     else:
-    	pixluname='DN' 
+        pixluname = 'DN'
 
     dict_header = {
-#    Change to the start time of the obs, not the mid_time?
-    "DATE-OBS": sta_obs_time.iso,#mid_obs_time.iso,
-    "EXPTIME": exp_time,
-    "ONTIME": on_time,
-    "CDELT1": scale,
-    "NAXIS1": bins,
-    "CRVAL1": 0.,
-    "CRPIX1": bins*0.5,
-    "CUNIT1": "arcsec",
-    "CTYPE1": "HPLN-TAN",
-    "CDELT2": scale,
-    "NAXIS2": bins,
-    "CRVAL2": 0.,
-    "CRPIX2": bins*0.5 + 0.5,
-    "CUNIT2": "arcsec",
-    "CTYPE2": "HPLT-TAN",
-    "PIXLUNIT": pixluname,
-    "DETECTOR":"NuSTAR",
-    "HGLT_OBS": sunpy.coordinates.sun.B0(mid_obs_time).value,
-    "HGLN_OBS": 0,
-#    previous form (i.e. -4d41m42.2166s, instead of -4.695060153501252) save to fits crashed
-    "RSUN_OBS": sunpy.coordinates.sun.angular_radius(mid_obs_time).value,
-    "RSUN_REF": sunpy.sun.constants.radius.value,   
-    # again need in m, not AU or save to fits crashed
-    "DSUN_OBS": sunpy.coordinates.sun.earth_distance(mid_obs_time).to_value('m')
+        # Change to the start time of the obs, not the mid_time?
+        "DATE-OBS": sta_obs_time.iso,#mid_obs_time.iso,
+        "EXPTIME": exp_time,
+        "ONTIME": on_time,
+        "CDELT1": scale.value,
+        "NAXIS1": bins,
+        "CRVAL1": 0.,
+        "CRPIX1": bins*0.5,
+        "CUNIT1": scale.unit.to_string(),
+        "CTYPE1": "HPLN-TAN",
+        "CDELT2": scale.value,
+        "NAXIS2": bins,
+        "CRVAL2": 0.,
+        "CRPIX2": bins*0.5 + 0.5,
+        "CUNIT2": scale.unit.to_string(),
+        "CTYPE2": "HPLT-TAN",
+        "PIXLUNIT": pixluname,
+        "DETECTOR":"NuSTAR",
+        "HGLT_OBS": sunpy.coordinates.sun.B0(mid_obs_time).value,
+        "HGLN_OBS": 0,
+        # previous form (i.e. -4d41m42.2166s, instead of -4.695060153501252) save to fits crashed
+        "RSUN_OBS": sunpy.coordinates.sun.angular_radius(mid_obs_time).value,
+        "RSUN_REF": sunpy.sun.constants.radius.value,   
+        # again need in m, not AU or save to fits crashed
+        "DSUN_OBS": sunpy.coordinates.sun.earth_distance(mid_obs_time).to_value('m')
     }
 
     header = sunpy.util.MetaDict(dict_header)


### PR DESCRIPTION
## Problem

There are instances when the scale in Sunpy maps produced by `nustar_pysolar.map.make_sunpy` is different for different event files, requiring either adding or removing a multiplier to scale between degrees and arcseconds.
It seems to be due to a combination of two things:
1. Different versions of Heasoft/nustardas write `TCDLT` entries with different units (sometimes in degrees, sometimes in arcseconds).
2. The units in `nustar_pysolar` are hardcoded into the methods.


## Resolution

We can resolve this by adding a feature in `nustar_pysolar` that reads the units from the header.


## Example

To demonstrate this, I am using a cleaned `evt` file from the May 29, 2018 observation generated using the following software versions:
- Heasoft: V6.27.2a (May 21, 2020)
- NuSTARDAS V1.9.2 (April 01, 2020)
- CALDB 20200526

The `TCDLT` entries are in units of deg/pixel while the map scale units in `nustar_pysolar` are in arcseconds.
The following is the produced map using the vanilla `nustar_pysolar` install:
![without_units](https://user-images.githubusercontent.com/90336258/224119225-2974b426-0eec-45ae-9d3f-3192f1a80fef.png)

The following is the produced map after modifying `maps.make_sunpy` to read units from the header:
![with_units](https://user-images.githubusercontent.com/90336258/224119333-224d0482-9740-49fb-97df-44181b36962d.png)

This change has also been tested using a cleaned `evt` file from newer versions of Heasoft, NuSTARDAS, and CALDB which write the `TCDLT` entry with units of arcsec/pixel, and the proper map is produced.